### PR TITLE
Use internal methods instead of service methods directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "babel-polyfill": "^6.3.14",
     "feathers-errors": "^1.1.5",
-    "feathers-query-filters": "^1.1.1",
+    "feathers-query-filters": "^1.5.1",
     "uberproto": "^1.1.2",
     "waterline-errors": "^0.10.1"
   },


### PR DESCRIPTION
This is for https://github.com/feathersjs/feathers/issues/218. Basically, if an adapter uses its own service methods internally (like doing a `get` after removing an item) they can't be the original service methods (like `get`, `create`, `find` etc.) directly since those can be modified by Feathers with mixins and hooks and we do not want those to run in that case.

For this adapter we now provide an internal `_get` (also see #7), `_find` (that ignores pagination), `_patch` (for user with update) and `_getOrFind` (for patch and remove many).
