### PR TITLE
fix for error Cannot read property '$in' of undefined on undefined va…

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -91,7 +91,7 @@ export function getWhere (query) {
 
     if (prop === '$or') {
       where.or = value;
-    } else if (value.$in) {
+    } else if (value && value.$in) {
       where[prop] = value.$in;
     } else {
       where[prop] = getValue(value, prop);


### PR DESCRIPTION
…lue in query

### Summary
Doing a find with query arguments, where one of the arguments has an undefined value causes error "Cannot read property '$in' of undefined" error.
