### PR TITLE
Fix feathers update method with null id and params criteria

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "feathers-errors": "^2.0.2",
     "feathers-query-filters": "^2.0.0",
-    "lodash.omit": "^4.3.0",
+    "lodash": "^4.17.4",
     "uberproto": "^1.1.2",
     "waterline-errors": "^0.10.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -153,6 +153,8 @@ class Service {
       }
     });
 
+    const preserveWhere = _.cloneDeep(where);
+
     let p;
     if (id) {
       p = this.Model.findOne(where);
@@ -161,7 +163,11 @@ class Service {
     }
     return p.then(instance => {
       if (!instance) {
-        throw new errors.NotFound(`No record found for criteria '${where}'`);
+        if (id) {
+          throw new errors.NotFound('No record found for id \'' + id + '\'');
+        } else {
+          throw new errors.NotFound('No record found for criteria \'' + JSON.stringify(preserveWhere) + '\'');
+        }
       }
       let copy;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import omit from 'lodash.omit';
+// import omit from 'lodash.omit';
 import Proto from 'uberproto';
 import filter from 'feathers-query-filters';
 import errors from 'feathers-errors';
@@ -101,7 +101,7 @@ class Service {
       where[this.id] = id;
     }
 
-    return this.Model.update({ where }, omit(data, this.id))
+    return this.Model.update({ where }, _.omit(data, this.id))
       .then(() => this._findOrGet(id, params))
       .catch(utils.errorHandler);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import Proto from 'uberproto';
 import filter from 'feathers-query-filters';
 import errors from 'feathers-errors';
 import * as utils from './utils';
+import * as _ from 'lodash';
 
 class Service {
   constructor (options) {
@@ -109,32 +110,72 @@ class Service {
     return this._patch(...args);
   }
 
-  update (id, data) {
+  _copy (data, instance) {
+    let copy = {};
+    Object.keys(instance.toJSON()).forEach(key => {
+      // NOTE (EK): Make sure that we don't waterline created fields to null
+      // just because a user didn't pass them in.
+      if ((key === 'createdAt' || key === 'updatedAt') && typeof data[key] === 'undefined') {
+        return;
+      }
+
+      if (typeof data[key] === 'undefined') {
+        copy[key] = null;
+//      } else {
+//        copy[key] = data[key];
+      }
+    });
+    Object.keys(data.toJSON()).forEach(key => {
+      if ((key === 'createdAt' || key === 'updatedAt')) {
+        return;
+      }
+      copy[key] = data[key];
+    })
+    return copy;
+  }
+
+  update (id, data, params) {
     if (Array.isArray(data)) {
       return Promise.reject(new errors.BadRequest('Not replacing multiple records. Did you mean `patch`?'));
     }
 
-    return this.Model.findOne({ id }).then(instance => {
+    const where = Object.assign({}, params.query);
+
+    if (id !== null) {
+      where[this.id] = id;
+    }
+
+    // remove any $... fields as they are parameters to be passed to the adaptor and
+    // shouldnt be used for the following find/findOne().
+    _.each(where, (v, k) => {
+      if (_.startsWith(k, '$')) {
+        delete where[k];
+      }
+    })
+
+    let p;
+    if (id) {
+      p = this.Model.findOne(where);
+    } else {
+      p = this.Model.find(where);
+    }
+    return p.then(instance => {
       if (!instance) {
-        throw new errors.NotFound(`No record found for id '${id}'`);
+        throw new errors.NotFound(`No record found for criteria '${where}'`);
+      }
+      let copy;
+
+      // handle criteria matching multiple documents
+      if (_.isArray(instance)) {
+        copy = [];
+        instance.forEach((e) => {
+          copy.push(this._copy(data, e));
+        });
+      } else {
+        copy = this._copy(data, instance);
       }
 
-      let copy = {};
-      Object.keys(instance.toJSON()).forEach(key => {
-        // NOTE (EK): Make sure that we don't waterline created fields to null
-        // just because a user didn't pass them in.
-        if ((key === 'createdAt' || key === 'updatedAt') && typeof data[key] === 'undefined') {
-          return;
-        }
-
-        if (typeof data[key] === 'undefined') {
-          copy[key] = null;
-        } else {
-          copy[key] = data[key];
-        }
-      });
-
-      return this._patch(id, copy, {});
+      return this._patch(id, copy, params);
     })
     .catch(utils.errorHandler);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -125,12 +125,12 @@ class Service {
 //        copy[key] = data[key];
       }
     });
-    Object.keys(data.toJSON()).forEach(key => {
+    Object.keys(data).forEach(key => {
       if ((key === 'createdAt' || key === 'updatedAt')) {
         return;
       }
       copy[key] = data[key];
-    })
+    });
     return copy;
   }
 
@@ -151,7 +151,7 @@ class Service {
       if (_.startsWith(k, '$')) {
         delete where[k];
       }
-    })
+    });
 
     let p;
     if (id) {

--- a/src/index.js
+++ b/src/index.js
@@ -121,8 +121,6 @@ class Service {
 
       if (typeof data[key] === 'undefined') {
         copy[key] = null;
-//      } else {
-//        copy[key] = data[key];
       }
     });
     Object.keys(data).forEach(key => {


### PR DESCRIPTION
### Summary

FeathersJS [manual](https://docs.feathersjs.com/api/services.html#updateid-data-params) states that the update method has 3 parameters (id, data, params), and "... id can also be null when updating multiple records with params.query containing the query criteria".  Currently feathers-waterline only supports (id, data) and only updates a single record.

This pull request brings feathers-waterline into alignment with the above documentation.

### Other Information

I've also added support for passing through $... controls to the adapter.
